### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.killbots.json
+++ b/org.kde.killbots.json
@@ -12,6 +12,12 @@
         "--socket=pulseaudio",
         "--socket=wayland"
     ],
+     "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/share/doc",
+        "/share/qlogging-categories6"
+    ],
     "modules": [
         {
             "name": "libkdegames",


### PR DESCRIPTION
The installed size reduced from 12.6 MB to 11.3 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.