### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.killbots.json
+++ b/org.kde.killbots.json
@@ -15,6 +15,8 @@
     "cleanup": [
         "/include",
         "/lib/cmake",
+        "/lib/qml",
+        "/share/carddecks",
         "/share/doc",
         "/share/qlogging-categories6"
     ],


### PR DESCRIPTION
This PR removes the /share/carddecks folder, which is not required for this game.